### PR TITLE
Add: route table association resource block

### DIFF
--- a/24975/24975.tf
+++ b/24975/24975.tf
@@ -81,3 +81,10 @@ resource "aws_route_table" "My_VPC_route_table" {
     Name = "My VPC Route Table"
   }
 }
+
+# Associate the Route Table with the Subnet
+resource "aws_route_table_association" "My_VPC_association" {
+  subnet_id      = aws_subnet.My_VPC_Subnet.id
+  route_table_id = aws_route_table.My_VPC_route_table.id
+}
+


### PR DESCRIPTION
When I run the `run.sh` script with your terraform configuration file, it works like charm. If I add the `aws_route_table_association` resource block, I end up with the same behaviour.