### PR TITLE
Configuration update for nested for_each providers

### DIFF
--- a/21416/providers.tf
+++ b/21416/providers.tf
@@ -1,13 +1,15 @@
 provider "aws" {
+  region = "us-west-1"
 }
 
 provider "aws" {
-  region = "us-west-2"
   alias = "us-west-2"
+  region = "us-west-2"
 }
 
 module "example" {
   source = "./modules/example"
+  for_each = toset(["hello"])
 
   providers = {
     aws.us-west-2 = aws.us-west-2


### PR DESCRIPTION
Test case for nested providers with module for_each

There are two scenarios here:

1. If you add a nested provider (similar to how to fix for 0.13.5 without for_each):  
    ``` 
    Module "example" cannot be used with for_each because it contains a nested
    provider configuration for "aws.us-west-2"
    ```
    
2. Without the nested provider configuration results in the original error message:

    ```
    To work with module.example.aws_vpc.tf-21416-us-west-2 its original provider
    configuration at
    module.example.provider["registry.terraform.io/hashicorp/aws"].us-west-2 is
    required, but it has been removed
    ```
